### PR TITLE
assert_ok: Remove `Debug` requirement for `Ok()` content

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -8,4 +8,8 @@ fn main() {
     // Needed for `assert_matches!` and `?` macro repetition
     // See https://doc.rust-lang.org/edition-guide/rust-2018/macros/at-most-once.html
     cfg.emit_rustc_version(1, 32);
+
+    if cfg.probe_rustc_version(1, 15) && !cfg.probe_rustc_version(1, 16) {
+        autocfg::emit("has_private_in_public_issue");
+    }
 }

--- a/src/assert_err.rs
+++ b/src/assert_err.rs
@@ -45,16 +45,16 @@ macro_rules! assert_err {
     };
     ($cond:expr) => {
         match $cond {
-            t @ Ok(..) => {
-                panic!("assertion failed, expected Err(..), got {:?}", t);
+            Ok(t) => {
+                panic!("assertion failed, expected Err(..), got Ok({:?})", t);
             },
             Err(e) => e,
         }
     };
     ($cond:expr, $($arg:tt)+) => {
         match $cond {
-            t @ Ok(..) => {
-                panic!("assertion failed, expected Err(..), got {:?}: {}", t, format_args!($($arg)+));
+            Ok(t) => {
+                panic!("assertion failed, expected Err(..), got Ok({:?}): {}", t, format_args!($($arg)+));
             },
             Err(e) => e,
         }
@@ -96,5 +96,15 @@ mod tests {
     fn custom_panic_message() {
         let res: Result<i32, ()> = Ok(42);
         assert_err!(res, "we are checking if there was an error with {:?}", res);
+    }
+
+    #[test]
+    fn does_not_require_err_debug() {
+        enum Foo {
+            Bar,
+        }
+
+        let res: Result<i32, Foo> = Err(Foo::Bar);
+        let _ = assert_err!(res);
     }
 }

--- a/src/assert_err.rs
+++ b/src/assert_err.rs
@@ -78,3 +78,23 @@ macro_rules! assert_err {
 macro_rules! debug_assert_err {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::assert_err!($($arg)*); })
 }
+
+#[cfg(test)]
+#[cfg(not(has_private_in_public_issue))]
+mod tests {
+    #[test]
+    #[should_panic(expected = "assertion failed, expected Err(..), got Ok(42)")]
+    fn default_panic_message() {
+        let res: Result<i32, ()> = Ok(42);
+        assert_err!(res);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "assertion failed, expected Err(..), got Ok(42): we are checking if there was an error with Ok(42)"
+    )]
+    fn custom_panic_message() {
+        let res: Result<i32, ()> = Ok(42);
+        assert_err!(res, "we are checking if there was an error with {:?}", res);
+    }
+}

--- a/src/assert_ok.rs
+++ b/src/assert_ok.rs
@@ -58,16 +58,16 @@ macro_rules! assert_ok {
     ($cond:expr) => {
         match $cond {
             Ok(t) => t,
-            e @ Err(..) => {
-                panic!("assertion failed, expected Ok(..), got {:?}", e);
+            Err(e) => {
+                panic!("assertion failed, expected Ok(..), got Err({:?})", e);
             }
         }
     };
     ($cond:expr, $($arg:tt)+) => {
         match $cond {
             Ok(t) => t,
-            e @ Err(..) => {
-                panic!("assertion failed, expected Ok(..), got {:?}: {}", e, format_args!($($arg)+));
+            Err(e) => {
+                panic!("assertion failed, expected Ok(..), got Err({:?}): {}", e, format_args!($($arg)+));
             }
         }
     };
@@ -108,5 +108,15 @@ mod tests {
     fn custom_panic_message() {
         let res = Err(());
         assert_ok!(res, "Everything is good with {:?}", res);
+    }
+
+    #[test]
+    fn does_not_require_ok_debug() {
+        enum Foo {
+            Bar,
+        }
+
+        let res: Result<Foo, ()> = Ok(Foo::Bar);
+        let _ = assert_ok!(res);
     }
 }

--- a/src/assert_ok.rs
+++ b/src/assert_ok.rs
@@ -90,3 +90,23 @@ macro_rules! assert_ok {
 macro_rules! debug_assert_ok {
     ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::assert_ok!($($arg)*); })
 }
+
+#[cfg(test)]
+#[cfg(not(has_private_in_public_issue))]
+mod tests {
+    #[test]
+    #[should_panic(expected = "assertion failed, expected Ok(..), got Err(())")]
+    fn default_panic_message() {
+        let res = Err(());
+        assert_ok!(res);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "assertion failed, expected Ok(..), got Err(()): Everything is good with Err(())"
+    )]
+    fn custom_panic_message() {
+        let res = Err(());
+        assert_ok!(res, "Everything is good with {:?}", res);
+    }
+}

--- a/src/assert_some.rs
+++ b/src/assert_some.rs
@@ -78,3 +78,27 @@ macro_rules! assert_some {
 macro_rules! debug_assert_some {
     ($($arg:tt)*) => (if core::cfg!(debug_assertions) { $crate::assert_some!($($arg)*); })
 }
+
+#[cfg(test)]
+#[cfg(not(has_private_in_public_issue))]
+mod tests {
+    #[test]
+    #[should_panic(expected = "assertion failed, expected Some(..), got None")]
+    fn default_panic_message() {
+        let maybe: Option<i32> = None;
+        let _ = assert_some!(maybe);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "assertion failed, expected Some(..), got None: we are checking if there was an error with None"
+    )]
+    fn custom_panic_message() {
+        let maybe: Option<i32> = None;
+        let _ = assert_some!(
+            maybe,
+            "we are checking if there was an error with {:?}",
+            maybe
+        );
+    }
+}

--- a/src/assert_some.rs
+++ b/src/assert_some.rs
@@ -101,4 +101,14 @@ mod tests {
             maybe
         );
     }
+
+    #[test]
+    fn does_not_require_some_debug() {
+        enum Foo {
+            Bar,
+        }
+
+        let res: Option<Foo> = Some(Foo::Bar);
+        let _ = assert_some!(res);
+    }
 }


### PR DESCRIPTION
This resolves #2 :)

If there is interest, I can create a similar PR for `assert_err!()` too.