### PR TITLE
Fix clippy lint error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
     nonstandard_style,
     dead_code,
     deprecated,
-    intra_doc_link_resolution_failure,
+    broken_intra_doc_links,
     trivial_casts,
     trivial_numeric_casts,
     unused_import_braces,


### PR DESCRIPTION
CI on `master` is currently showing the following error when running the clippy lint job:

> error: lint `intra_doc_link_resolution_failure` has been renamed to `broken_intra_doc_links`

This PR fixes the outdated lint rule name.