### PR TITLE
Fix compatibility issues with various versions of Rust.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,11 @@ jobs:
           - nightly
     steps:
     - uses: actions/checkout@v2
-    - run: rustup target add thumbv6m-none-eabi
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ matrix.rust }}
+        target: thumbv6m-none-eabi
+        override: true
     - uses: actions-rs/cargo@v1
       with:
         command: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         toolchain:
+          - 1.0.0  # minimum supported rust version
           - 1.10.0  # old enough
           - 1.15.0
           - 1.20.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,15 +54,16 @@ jobs:
 
   no_std:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - stable
+          - beta
+          - nightly
     steps:
-      - uses: actions/checkout@v1
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - name: Install cargo-nono
-        run: cargo install cargo-nono
-      - name: Check no_std
-        run: cargo nono check
+    - uses: actions/checkout@v2
+    - run: rustup target add thumbv6m-none-eabi
+    - uses: actions-rs/cargo@v1
+      with:
+        command: build
+        args: --target thumbv6m-none-eabi --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           - 1.15.0
           - 1.20.0
           - 1.25.0
+          - 1.30.0
           - 1.31.0  # edition2018
           - 1.36.0
           - 1.37.0  # assert_matches! min compat version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "claim"
 description = "Assertion macros"
 version = "0.4.0"
 authors = ["svartalf <self@svartalf.info>"]
-edition = "2018"
 license = "Apache-2.0 OR MIT"
 categories = ["development-tools", "development-tools::testing", "no-std"]
 keywords = ["assert", "test", "testing"]

--- a/build.rs
+++ b/build.rs
@@ -8,9 +8,8 @@ fn main() {
     // Needed to enable `#![no_std]` only on rustc versions that support it (rustc 1.6.0 and up).
     cfg.emit_rustc_version(1, 6);
 
-    // Needed for `assert_matches!` and `?` macro repetition
-    // See https://doc.rust-lang.org/edition-guide/rust-2018/macros/at-most-once.html
-    cfg.emit_rustc_version(1, 32);
+    // Needed for `assert_matches!`' minimum rust version.
+    cfg.emit_rustc_version(1, 26);
 
     if cfg.probe_rustc_version(1, 15) && !cfg.probe_rustc_version(1, 16) {
         autocfg::emit("has_private_in_public_issue");

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,9 @@ fn main() {
     cfg.emit_path_cfg("core::task::Poll", "has_task_poll");
     cfg.emit_path_cfg("std::task::Poll", "has_task_poll");
 
+    // Needed to enable `#![no_std]` only on rustc versions that support it (rustc 1.6.0 and up).
+    cfg.emit_rustc_version(1, 6);
+
     // Needed for `assert_matches!` and `?` macro repetition
     // See https://doc.rust-lang.org/edition-guide/rust-2018/macros/at-most-once.html
     cfg.emit_rustc_version(1, 32);

--- a/src/assert_matches.rs
+++ b/src/assert_matches.rs
@@ -41,23 +41,43 @@
 /// [`debug_assert_matches!`]: ./macro.debug_assert_matches.html
 #[macro_export]
 macro_rules! assert_matches {
-    ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )?) => {
+    ($expression:expr, $( $pattern:pat )|+) => {
         match $expression {
-            $( $pattern )|+ $( if $guard )? => {},
+            $( $pattern )|+ => {},
             other => {
                 panic!(r#"assertion failed, expression does not match any of the given variants.
     expression: {:?}
-    variants: {}"#, other, stringify!($($pattern) |+ $(if $guard)?));
+    variants: {}"#, other, stringify!($($pattern) |+));
             }
         }
     };
-    ($expression:expr, $( $pattern:pat )|+ $( if $guard: expr )?, $($arg:tt)+) => {
+    ($expression:expr, $( $pattern:pat )|+ if $guard: expr) => {
         match $expression {
-            $( $pattern )|+ $( if $guard )? => {},
+            $( $pattern )|+ if $guard => {},
             other => {
                 panic!(r#"assertion failed, expression does not match any of the given variants.
     expression: {:?}
-    variants: {}: {}"#, other, stringify!($($pattern) |+ $(if $guard)?), format_args!($($arg)+));
+    variants: {}"#, other, stringify!($($pattern) |+ if $guard));
+            }
+        }
+    };
+    ($expression:expr, $( $pattern:pat )|+, $($arg:tt)+) => {
+        match $expression {
+            $( $pattern )|+ => {},
+            other => {
+                panic!(r#"assertion failed, expression does not match any of the given variants.
+    expression: {:?}
+    variants: {}: {}"#, other, stringify!($($pattern) |+), format_args!($($arg)+));
+            }
+        }
+    };
+    ($expression:expr, $( $pattern:pat )|+ if $guard: expr, $($arg:tt)+) => {
+        match $expression {
+            $( $pattern )|+ if $guard => {},
+            other => {
+                panic!(r#"assertion failed, expression does not match any of the given variants.
+    expression: {:?}
+    variants: {}: {}"#, other, stringify!($($pattern) |+ if $guard), format_args!($($arg)+));
             }
         }
     };

--- a/src/assert_matches.rs
+++ b/src/assert_matches.rs
@@ -1,6 +1,6 @@
 /// Asserts that expression matches any of the given variants.
 ///
-/// This macro is available for Rust 1.32+.
+/// This macro is available for Rust 1.26+.
 ///
 /// It works exactly as [`std::matches!`] macro,
 /// except it panics if there is no match.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,5 +119,5 @@ mod assert_ready_err;
 #[cfg(has_task_poll)]
 mod assert_ready_ok;
 
-#[cfg(rustc_1_32)]
+#[cfg(rustc_1_26)]
 mod assert_matches;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![no_std]
+#![cfg_attr(rustc_1_6, no_std)]
 #![doc(html_root_url = "https://docs.rs/claim/0.4.0")]
 #![allow(unknown_lints, unused_extern_crates)]
 #![forbid(


### PR DESCRIPTION
Fix for #5. This allows the crate to be used in all versions of Rust, from `1.0.0` upwards, as specified by the Rust version badge. I have also added coverage for each of these versions to the CI, so that they don't accidentally break again in the future :)

I had to remove the Kleene operator (`?`) from `assert_matches!` in order to not lose coverage in `rustc 1.32.0`, since the operator requires edition 2018 in order to be used before `rustc 1.37.0`. I simply broke the optional arguments into separate matchers. Interestingly, this allows `assert_matches!` to be used in earlier `rustc` versions. I bumped the MSRV for it back to `1.26.0`, because that's as far back as it tests, but you could probably move it even further back by making the tests compatible (it builds all the way back to version `1.7.0`, and the only thing holding it back is that the tests aren't compatible before `1.26.0`). For now, I've left it at `1.26.0`.