### PR TITLE
Add `assert_err_eq!` macro

### DIFF
--- a/src/assert_err_eq.rs
+++ b/src/assert_err_eq.rs
@@ -1,0 +1,99 @@
+/// Asserts that expression returns [`Err(E)`] variant
+/// and its value of `E` type equals to the right expression.
+///
+/// ## Uses
+///
+/// Assertions are always checked in both debug and release builds, and cannot be disabled.
+/// See [`debug_assert_err_eq!`] for assertions that are not enabled in release builds by default.
+///
+/// ## Custom messages
+///
+/// This macro has a second form, where a custom panic message can be provided
+/// with or without arguments for formatting. See [`std::fmt`] for syntax for this form.
+///
+/// ## Examples
+///
+/// ```rust
+/// # #[macro_use] extern crate claim;
+/// # fn main() {
+/// let res: Result<(), i32> = Err(1);
+///
+/// assert_err_eq!(res, 1);
+///
+/// // With custom messages
+/// assert_err_eq!(res, 1, "Everything is good with {:?}", res);
+/// # }
+/// ```
+///
+/// Value of `E` type from `Err(E)` will be returned from the macro call:
+///
+/// ```rust
+/// # #[macro_use] extern crate claim;
+/// # fn main() {
+/// let res: Result<(), i32> = Err(1);
+///
+/// let value = assert_err_eq!(res, 1);
+/// assert_eq!(value, 1);
+/// # }
+/// ```
+///
+/// `Ok(..)` variant will cause panic:
+///
+/// ```rust,should_panic
+/// # #[macro_use] extern crate claim;
+/// # fn main() {
+/// let res: Result<(), i32> = Ok(());
+///
+/// assert_err_eq!(res, 1);  // Will panic
+/// # }
+/// ```
+///
+/// [`Err(E)`]: https://doc.rust-lang.org/core/result/enum.Result.html#variant.Err
+/// [`std::fmt`]: https://doc.rust-lang.org/std/fmt/index.html
+/// [`debug_assert_err_eq!`]: ./macro.debug_assert_err_eq.html
+#[macro_export]
+macro_rules! assert_err_eq {
+    ($cond:expr, $expected:expr,) => {
+        $crate::assert_err_eq!($cond, $expected);
+    };
+    ($cond:expr, $expected:expr) => {
+        match $cond {
+            Err(t) => {
+                assert_eq!(t, $expected);
+                t
+            },
+            ok @ Ok(..) => {
+                panic!("assertion failed, expected Err(..), got {:?}", ok);
+            }
+        }
+    };
+    ($cond:expr, $expected:expr, $($arg:tt)+) => {
+        match $cond {
+            Err(t) => {
+                assert_eq!(t, $expected);
+                t
+            },
+            ok @ Ok(..) => {
+                panic!("assertion failed, expected Err(..), got {:?}: {}", ok, format_args!($($arg)+));
+            }
+        }
+    };
+}
+
+/// Asserts that expression returns [`Err(E)`] variant in runtime.
+///
+/// Like [`assert_err_eq!`], this macro also has a second version,
+/// where a custom panic message can be provided.
+///
+/// ## Uses
+///
+/// See [`debug_assert!`] documentation for possible use cases.
+/// The same applies to this macro.
+///
+/// [`Err(E)`]: https://doc.rust-lang.org/core/result/enum.Result.html#variant.Err
+/// [`debug_assert!`]: https://doc.rust-lang.org/std/macro.debug_assert.html
+/// [`assert_err_eq!`]: ./macro.assert_err_eq.html
+#[macro_export]
+macro_rules! debug_assert_err_eq {
+    ($($arg:tt)*) => (if cfg!(debug_assertions) { $crate::assert_err_eq!($($arg)*); })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,8 +99,8 @@
 //! [`assert_ready_eq`]: ./macro.assert_ready_eq.html
 //! [`assert_matches`]: ./macro.assert_matches.html
 
-mod assert_err_eq;
 mod assert_err;
+mod assert_err_eq;
 mod assert_ge;
 mod assert_gt;
 mod assert_le;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,7 @@
 //! * [`assert_ok`]
 //! * [`assert_err`]
 //! * [`assert_ok_eq`]
+//! * [`assert_err_eq`]
 //!
 //! ### `Option` macros
 //!
@@ -90,6 +91,7 @@
 //! [`assert_ok`]: ./macro.assert_ok.html
 //! [`assert_err`]: ./macro.assert_err.html
 //! [`assert_ok_eq`]: ./macro.assert_ok_eq.html
+//! [`assert_err_eq`]: ./macro.assert_err_eq.html
 //! [`assert_ready`]: ./macro.assert_ready.html
 //! [`assert_ready_ok`]: ./macro.assert_ready_ok.html
 //! [`assert_ready_err`]: ./macro.assert_ready_err.html
@@ -97,6 +99,7 @@
 //! [`assert_ready_eq`]: ./macro.assert_ready_eq.html
 //! [`assert_matches`]: ./macro.assert_matches.html
 
+mod assert_err_eq;
 mod assert_err;
 mod assert_ge;
 mod assert_gt;


### PR DESCRIPTION
Introduces an `assert_err_eq!` macro, which asserts that a `Result` value is an `Err` and that its contained value is equal to the provided value. Also defines a `debug_assert_err_eq!` macro.

This is very similar to the `assert_ok_eq!` macro, and I think this nicely fills out the macros provided by this library. Similarly, the `debug_assert_err_eq!` macro is very similar to the `debug_assert_ok_eq!` macro.

This closes #7.