### PR TITLE
autocfg: Allow all v1.x releases

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ maintenance = { status = "actively-developed" }
 github-actions = { repository = "svartalf/rust-claim", workflow = "Continuous integration" }
 
 [build-dependencies]
-autocfg = "~1.0"
+autocfg = "1.0"


### PR DESCRIPTION
`claim` is currently incompatible with any crate that requires `autocfg = "1.1"`, because only one copy of each semver-major version can exist in the lockfile (see https://github.com/rust-lang/crates.io/pull/4763#issuecomment-1121101295).

This PR relaxes the dependency requirement on `autocfg` from `1.0.x` to `1.x` to fix the incompatibility.

Resolves #9 