### PR TITLE
updating dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ maintenance = { status = "actively-developed" }
 github-actions = { repository = "svartalf/rust-claim", workflow = "Continuous integration" }
 
 [build-dependencies]
-autocfg = "~1.0"
+autocfg = "~1.1"


### PR DESCRIPTION
When trying to import this crate into a project that uses tokio, a dependency resolving issue occurs. Tokio is using the latest autocfg while this package is one version behind. The need for the update comes as when a cargo audit is run on a package with a tokio version that works with claims (ie they both use autocfg 1.0), a vulnerability in the tokio package is reported. The vulnerability has been patched in its newer versions, which all use autocfg 1.1. By updating autocfg to 1.1, these issues go away.